### PR TITLE
Update pending.json

### DIFF
--- a/pending.json
+++ b/pending.json
@@ -626,7 +626,7 @@
     },
     {
         "id": "com.samsung.android.providers.media",
-        "description": "Likely same as com.android.providers.media; scans the device for media files and allows permitted apps access to them.",
+        "description": "Likely same as com.android.providers.media; scans the device for media files and allows permitted apps access to them. Disabling this package can cause issues with saving screenshots.",
         "removal": "caution"
     },
     {


### PR DESCRIPTION
Added note on com.samsung.android.providers.media entry regarding screenshot issue when this package is disabled. Error message will state an issue with security policy. Tested on Samsung Galaxy S20 (Android 13) and S22 (Android 14)